### PR TITLE
setup.py python_requires=">=3.8"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "requests>=2.31.0,<2.32.0",
         "rich>=12.5.1,<12.6.0",
     ],
+    python_requires=">=3.8",
     include_package_data=True,
     zip_safe=True,
     license="MIT",


### PR DESCRIPTION
because otherwise ggshield happily installs on e.g a python 3.7 despite the README claims to support only python 3.8+. It currently works but it is going to bite our customer hard the day we push code breaking compatibility with python <= 3.7.

```                                                                                                                      
➜  ggshield git:(python-requires-3.8) ✗ python --version                                                                                                                        
Python 3.7.17
➜  ggshield git:(python-requires-3.8) ✗ pip install ggshield
[...]
Successfully installed appdirs-1.4.4 certifi-2023.7.22 cffi-1.15.1 charset-normalizer-3.1.0 click-8.1.7 commonmark-0.9.1 cryptography-41.0.3 ggshield-1.18.1 idna-3.4 importlib-metadata-6.7.0 marshmallow-3.18.0 marshmallow-dataclass-8.5.14 mypy-extensions-1.0.0 oauthlib-3.2.2 packaging-23.1 pycparser-2.21 pygitguardian-1.9.0 pygments-2.16.1 pyjwt-2.6.0 python-dotenv-0.21.1 pyyaml-6.0.1 requests-2.31.0 rich-12.5.1 typing-extensions-4.7.1 typing-inspect-0.9.0 urllib3-2.0.4 zipp-3.15.0
➜  ggshield git:(python-requires-3.8) ✗ pip show ggshield                                                                                                                       
Name: ggshield
Version: 1.18.1
Summary: Detect secrets from all sources using GitGuardian's brains
Home-page: https://github.com/GitGuardian/ggshield
Author: GitGuardian
Author-email: support@gitguardian.com
License: MIT
Location: /Users/mathieu/.pyenv/versions/3.7.17/lib/python3.7/site-packages
Requires: appdirs, charset-normalizer, click, cryptography, marshmallow, marshmallow-dataclass, oauthlib, pygitguardian, pyjwt, python-dotenv, pyyaml, requests, rich
➜  ggshield git:(python-requires-3.8) ✗ ggshield --version                                                                                                                      
ggshield, version 1.18.1
```